### PR TITLE
add synchronous return values

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,17 @@ var htmltree = require("htmltree");
 module.exports = virtualHTML;
 
 function virtualHTML (html, callback) {
+  callback = callback || function () {};
   if (typeof html == 'function') html = html();
+  var res = null;
 
   htmltree(html, function (err, dom) {
     if (err) return callback(err);
-    callback(undefined, vnode(dom.root[0]));
+    res = vnode(dom.root[0]);
+    callback(undefined, res);
   });
+
+  return res;
 }
 
 function vnode (parent) {

--- a/test.js
+++ b/test.js
@@ -17,3 +17,10 @@ test('creating virtual dom from HTML', function (t) {
     t.equal(dom.properties.dataset.yo, 'hola');
   });
 });
+
+test('returns a virtual dom from HTML', function (t) {
+  t.plan(1);
+
+  var dom = virtual(simple);
+  t.equal(dom.tagName.toLowerCase(), 'div');
+});


### PR DESCRIPTION
Adds return values next to callbacks so that `virtual-html` can be used with synchronous interfaces. An example of such an interface is [`deku`](http://ghub.io/deku), where dom nodes are constructed as:

``` js
myComponent.prototype.render = function (props, state) {
  return dom('button', { onClick: this.onClick }, [props.text]);
}
```

Hope it's useful, thanks!
