### PR TITLE
add default error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var htmltree = require("htmltree");
 module.exports = virtualHTML;
 
 function virtualHTML (html, callback) {
-  callback = callback || function () {};
+  callback = callback || defaultCb;
   if (typeof html == 'function') html = html();
   var res = null;
 
@@ -15,6 +15,10 @@ function virtualHTML (html, callback) {
   });
 
   return res;
+
+  function defaultCb (err) {
+    if (err) throw new Error(err);
+  }
 }
 
 function vnode (parent) {

--- a/test.js
+++ b/test.js
@@ -24,3 +24,8 @@ test('returns a virtual dom from HTML', function (t) {
   var dom = virtual(simple);
   t.equal(dom.tagName.toLowerCase(), 'div');
 });
+
+test('should throw if an error is found and no callback is provided', function (t) {
+  t.plan(1);
+  t.throws(virtual.bind(null, null));
+});


### PR DESCRIPTION
Adds default error handling so that errors are not swallowed silently when using the synchronous interface introduced in #2. Not sure if `throw` is the right way to go here though, let me know if another method is preferable. Thanks!
