### PR TITLE
camelCase dataset keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,9 +79,15 @@ function createDataSet (props) {
   for (key in props) {
     if (key.slice(0, 5) == 'data-') {
       dataset || (dataset = {});
-      dataset[key.slice(5)] = props[key];
+      dataset[camelCase(key.slice(5))] = props[key];
     }
   }
 
   return dataset;
+}
+
+function camelCase (name) {
+  return name.toLowerCase().replace(/-(.)/g, function(match, letter) {
+    return letter.toUpperCase();
+  });
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var createVNode = require('virtual-dom/h');
 var htmltree = require("htmltree");
+var camel = require('to-camel-case');
 
 module.exports = virtualHTML;
 
@@ -79,15 +80,9 @@ function createDataSet (props) {
   for (key in props) {
     if (key.slice(0, 5) == 'data-') {
       dataset || (dataset = {});
-      dataset[camelCase(key.slice(5))] = props[key];
+      dataset[camel(key.slice(5))] = props[key];
     }
   }
 
   return dataset;
-}
-
-function camelCase (name) {
-  return name.toLowerCase().replace(/-(.)/g, function(match, letter) {
-    return letter.toUpperCase();
-  });
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "BSD",
   "dependencies": {
     "htmltree": "0.0.4",
+    "to-camel-case": "^0.2.1",
     "virtual-dom": "^2.0.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,10 +1,10 @@
 var virtual = require('./');
 var test = require("prova");
 
-var simple = '<div class="foo bar" style="color: red; background: yellow; background-image: url(http://f-oo.com/bar.jpg?qux=corge&span=eggs);" data-foo="bar" data-yo="hola" for="woot">yo</div>';
+var simple = '<div class="foo bar" style="color: red; background: yellow; background-image: url(http://f-oo.com/bar.jpg?qux=corge&span=eggs);" data-foo="bar" data-yo="hola" data-two-word="hello" for="woot">yo</div>';
 
 test('creating virtual dom from HTML', function (t) {
-  t.plan(8);
+  t.plan(9);
 
   virtual(simple, function (error, dom) {
     if (error) t.error(error);
@@ -15,6 +15,7 @@ test('creating virtual dom from HTML', function (t) {
     t.equal(dom.properties.style['background-image'], 'url(http://f-oo.com/bar.jpg?qux=corge&span=eggs)');
     t.equal(dom.properties.dataset.foo, 'bar');
     t.equal(dom.properties.dataset.yo, 'hola');
+    t.equal(dom.properties.dataset.twoWord, 'hello');
     t.equal(dom.properties.htmlFor, 'woot');
   });
 });


### PR DESCRIPTION
dataSet keys need to be camel cased when using hyphens in names (currently get an invalid name error)

e.g. two-word => twoWord
